### PR TITLE
typos and universal formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 #StickyState
 
-StickyState ads state to position:sticky elements and also polyfills the missing native sticky feature.
+StickyState adds state to position:sticky elements and also polyfills the missing native sticky feature.
 
-todays browser do not all support the position:sticky feature (which by the way is beeing used (polyfilled) on pretty much every site you visit) - moreover the native supported feature itself comes without a readable state. something like a:hover => div:sticky to add different styles to the element in its sticky state - or to read the state if needed in javacript. 
+Today's browsers do not all support the position:sticky feature (which by the way is being used (polyfilled) on pretty much every site you visit) - moreover the native supported feature itself comes without a readable state. Something like `a:hover => div:sticky` to add different styles to the element in its sticky state - or to read the state if needed in JavaScript. 
 
-unlike almost all polyfills you can find in the wild StickyState is high perfomant. the calculations are reduced to a minimum by persisting several attributes.
+Unlike almost all polyfills you can find in the wild, StickyState is highly performant. The calculations are reduced to a minimum by persisting several attributes.
 
-###Dependencies
+### Dependencies
 none!
 
-###Browser support
+### Browser support
 IE >= 9, *
 
-###install
+### install
 ```
 npm install sticky-state
 ```
 ### demo
 https://rawgit.com/soenkekluth/sticky-state/master/examples/index.html
 
-###css
-your css should contain the following lines: 
+### css
+Your css should contain the following lines: 
 (you can specify the classNames in js)
 ```css
 .sticky {
@@ -37,7 +37,7 @@ your css should contain the following lines:
 }
 ```
 
-###js
+### js
 ```javascript
 var StickyState = require('sticky-state');
 new StickyState(yourElement);
@@ -45,5 +45,5 @@ new StickyState(yourElement);
 StickyState.apply(document.querySelectorAll('.sticky'));
 // for example
 ```
-###React Component
+### React Component
 https://github.com/soenkekluth/react-sticky-state


### PR DESCRIPTION
The 'universal formatting' just refers to the spaces I added after the header tags so that other Markdown readers (like on npmjs.org) format the headers properly.
