### PR TITLE
Fix resizing issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,6 +271,7 @@ StickyState.prototype.removeResizeHandler = function() {
 };
 
 StickyState.prototype.onScroll = function(e) {
+  this.updateBounds(true);
   this.updateStickyState(false);
   if (this.hasOwnScrollTarget && !this.canSticky()) {
     this.updateFixedOffset();

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ StickyState.prototype.getBounds = function(noCache) {
 
 StickyState.prototype.updateBounds = function(silent) {
   silent = silent === true;
-  this.setState(this.getBounds(), silent);
+  this.setState(this.getBounds(true), silent);
 };
 
 StickyState.prototype.updateFixedOffset = function() {

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ var StickyState = function(element, options) {
     disabled: this.options.disabled
   }, true);
 
+  this.initialStyle = getPositionStyle(this.el);
   this.scrollTarget = (window.getComputedStyle(this.el.parentNode).overflow !== 'auto' ? window : this.el.parentNode);
   this.hasOwnScrollTarget = this.scrollTarget !== window;
   if (this.hasOwnScrollTarget) {
@@ -295,8 +296,8 @@ StickyState.prototype.getStickyState = function() {
   }
 
   var scrollY = this.fastScroll.scrollY;
-  var top = this.state.style.top;
-  var bottom = this.state.style.bottom;
+  var top = this.initialStyle.top;
+  var bottom = this.initialStyle.bottom;
   var sticky = this.state.sticky;
   var absolute = this.state.absolute;
 


### PR DESCRIPTION
I am facing issue #13 with my responsive bootstrap website, the positioning breaks when media query triggered (Page Height Changed). 

I have traced the code a bit and found that its from [getStickyState](https://github.com/soenkekluth/sticky-state/blob/master/index.js#L291) `this.state.style.top` and `this.state.style.bottom` keep changing and cause flickering after size changed.
(Please take a look on #13 and try resize browser window)

The flickering disappeared when I try to set `top` and `bottom` to initial style. 

I dun know which is the best way to solve it, but hope you find this useful~ Thx~
